### PR TITLE
修复 SW 陈旧缓存导致评论区等懒加载面板永久空白

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ VITE_VNDB_API_URL=https://api.vndb.org/kana/v1
 # ============================================
 VITE_STATUS_URL=https://status.searchgal.top
 VITE_ARTALK_SERVER=https://artalk.saop.cc
+VITE_ARTALK_SITE=旮旯聚搜
 VITE_IMAGE_API_URL=https://api.illlights.com/v1/img
 
 # ============================================

--- a/src/components/CommentsModal.vue
+++ b/src/components/CommentsModal.vue
@@ -76,6 +76,7 @@ import { playTransitionUp, playTransitionDown } from '@/composables/useSound'
 import Artalk from 'artalk/dist/Artalk.mjs'
 import 'artalk/dist/Artalk.css'
 import { MessageCircle, ChevronLeft, X, Sparkles, Send } from '@lucide/vue'
+import { config } from '@/config'
 
 interface ArtalkInstance {
   destroy(): void
@@ -136,28 +137,33 @@ function initArtalk() {
     try {
       artalkInstance.destroy()
       artalkInstance = null
-    } catch {
-      // 静默处理错误
+    } catch (error) {
+      console.warn('[Artalk] 销毁旧实例失败：', error)
+      artalkInstance = null
     }
   }
 
   void nextTick(() => {
     const commentsEl = document.getElementById('Comments')
-    if (commentsEl) {
-      try {
-        artalkInstance = Artalk.init({
-          el: '#Comments',
-          pageKey: '/',
-          server: 'https://artalk.saop.cc',
-          site: '旮旯聚搜',
-          darkMode: 'auto',
-        })
-        
-        // 尝试滚动到指定评论
-        scrollToComment()
-      } catch {
-        // 静默处理错误
-      }
+    if (!commentsEl) {
+      console.error('[Artalk] 未找到挂载点 #Comments，评论区无法初始化')
+      return
+    }
+
+    try {
+      artalkInstance = Artalk.init({
+        el: '#Comments',
+        pageKey: '/',
+        server: config.services.artalkServer,
+        site: config.services.artalkSite,
+        darkMode: 'auto',
+      })
+
+      // 尝试滚动到指定评论
+      scrollToComment()
+    } catch (error) {
+      // 不再静默：初始化失败时评论区会是空白，必须留下可诊断的线索
+      console.error('[Artalk] 初始化失败：', error)
     }
   })
 }

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -23,6 +23,7 @@ interface AppConfig {
   services: {
     statusUrl: string
     artalkServer: string
+    artalkSite: string
     imageApiUrl: string
   }
   
@@ -126,6 +127,7 @@ export const config: AppConfig = {
   services: {
     statusUrl: getEnv('VITE_STATUS_URL', 'https://status.searchgal.top'),
     artalkServer: getEnv('VITE_ARTALK_SERVER', 'https://artalk.saop.cc'),
+    artalkSite: getEnv('VITE_ARTALK_SITE', '旮旯聚搜'),
     imageApiUrl: getEnv('VITE_IMAGE_API_URL', 'https://api.illlights.com/v1/img'),
   },
   

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,31 @@ import { vRipple } from './directives/vRipple'
 // 文本滚动指令
 import { vTextScroll } from './composables/useTextScroll'
 
+// ============================================
+// 陈旧 chunk 自愈
+// ============================================
+// 用户停留期间若发生了新的发版，页面里旧的 chunk 文件名已从服务器移除，
+// 此时懒加载（评论区、设置面板等）请求会被 SPA 回退成 text/html，
+// 浏览器拒绝将其作为 ES module 执行。Vite 会为这类失败派发 vite:preloadError，
+// 这里捕获后重载一次以取回最新 HTML。用 sessionStorage 打标防止重载死循环。
+// 用「上次重载时间」而非布尔标记做防护：重载后页面会重新执行本文件，
+// 布尔标记若在 load 时清掉就挡不住循环——若 chunk 依然缺失会无限重载。
+// 时间窗内不再重载，超过窗口（下一次发版）则重新具备自愈能力。
+const RELOAD_AT_KEY = 'sg:chunk-reload-at'
+const RELOAD_COOLDOWN = 10_000
+
+window.addEventListener('vite:preloadError', (event) => {
+  const last = Number(sessionStorage.getItem(RELOAD_AT_KEY) ?? 0)
+  if (Date.now() - last < RELOAD_COOLDOWN) {
+    // 刚重载过仍失败，说明不是版本错配，放行让错误正常抛出便于排查
+    console.error('[chunk] 重载后仍无法加载资源，放弃自愈：', event)
+    return
+  }
+  sessionStorage.setItem(RELOAD_AT_KEY, String(Date.now()))
+  event.preventDefault()
+  window.location.reload()
+})
+
 const app = createApp(App)
 
 // 注册全局指令

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -76,7 +76,13 @@ export default defineConfig({
       },
       workbox: {
         // 预缓存核心构建产物（首屏必需，不包含字体——字体按 unicode-range 子集太多，改为运行时缓存）
-        globPatterns: ['**/*.{js,css,html,svg,ico}'],
+        //
+        // 注意：这里刻意不含 html。index.html 若进预缓存会被 cache-first 永久命中，
+        // 返回的是上一个版本的 HTML，而它引用的懒加载 chunk（见下方 globIgnores）
+        // 并未预缓存、发版后已从服务器消失，请求会被 SPA 回退成 text/html，
+        // 浏览器拒绝将其作为 ES module 执行 —— 表现为评论区等面板永久空白，
+        // 必须手动清理 SW 才能恢复。HTML 改由下方 NetworkFirst 规则处理。
+        globPatterns: ['**/*.{js,css,svg,ico}'],
         // 单文件最大预缓存 3 MB，避免大依赖膨胀 precache
         maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
         // 排除按需加载的资源（评论、编辑器在用户触发时再缓存）
@@ -88,6 +94,19 @@ export default defineConfig({
         ],
         // 运行时缓存策略
         runtimeCaching: [
+          {
+            // HTML 导航 - 网络优先，保证 HTML 与其引用的 chunk 始终同属一次发版；
+            // 断网时回退到上次缓存的 HTML，离线能力不受影响
+            urlPattern: ({ request }: { request: Request }) => request.mode === 'navigate',
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'html-shell',
+              networkTimeoutSeconds: 3,
+              expiration: {
+                maxEntries: 4,
+              },
+            },
+          },
           {
             // 本地字体子集 - 缓存优先（用户用到哪个子集才缓存哪个）
             urlPattern: /\/fonts\/.*\.(woff2?|ttf|otf)$/i,


### PR DESCRIPTION
## 症状

评论区一直空白，**必须手动清理 service worker 才能加载出来**。

## 根因

问题不在 artalk，而在 `vite.config.ts` 里两条 workbox 配置的组合：

```js
globPatterns: ['**/*.{js,css,html,svg,ico}'],           // index.html 进了预缓存
globIgnores:  ['**/artalk-*', '**/CommentsModal-*', …]  // 它引用的 chunk 却不进
```

预缓存是 **cache-first 永久命中**。生产环境实测确认：

```
precacheHasIndexHtml:      true    ← 旧 HTML 被永久缓存
precacheHasCommentsModal:  false   ← 它引用的 chunk 不在缓存里
```

失效链路：

1. 老用户的 SW 返回**上个版本的 index.html**
2. 该 HTML 引用 `CommentsModal-<旧hash>.js`
3. 该文件发版后已从服务器移除
4. Cloudflare Pages 对不存在路径回退返回 **HTTP 200 + `text/html`**（不是 404，已 curl 验证）
5. 浏览器拒绝把 HTML 当 ES module 执行，动态导入失败
6. `initArtalk()` 的 `catch {}` 静默吞掉 → **永久空白**

清理 SW 后拿到新 HTML 即恢复，与报告的症状完全吻合。

> 受影响的不止评论区 —— `globIgnores` 里的 `editor-*`、`SettingsModal-*` 同样中招。

## 修复

**1. HTML 不再预缓存** — 把 `html` 移出 `globPatterns`，改由 NetworkFirst 运行时规则处理导航请求。HTML 与其引用的 chunk 从此始终同属一次发版。断网时回退到缓存，离线能力不变。

**2. 陈旧 chunk 自愈** — 监听 Vite 的 `vite:preloadError`，捕获后重载一次取回最新 HTML。覆盖「用户开着页面时发版」这个 SW 修复够不着的窗口。

**3. 不再静默吞错误** — `initArtalk()` 的空 `catch` 改为打日志。这正是问题难以定位的原因。

顺带修正配置漂移：组件内硬编码的 server/site 改用 `config.services.*`，`VITE_ARTALK_SERVER` 恢复生效；补上缺失的 `artalkSite` 定义与 `.env.example` 条目。

## 自愈逻辑的一个坑

第一版用布尔标记防重载循环，测试时发现 **`load` 事件会在重载后立刻清掉标记** —— 若 chunk 仍缺失会无限重载。已改为时间戳冷却窗（10 秒）。

## 验证

生成的 `sw.js` 断言：

- `index.html` 已移出预缓存
- `html-shell` NetworkFirst 路由正确序列化为 `({request:e})=>"navigate"===e.mode`

自愈逻辑实测（删除 chunk 模拟发版后旧文件消失）：

- `vite:preloadError` 触发 ✓
- 执行**恰好一次**重载（`navType: reload`）✓
- 29.7 秒内**未再重载**，无循环 ✓

功能无回归：dev 下评论区正常加载 231 条评论，编辑器与列表均正常。`pnpm check` + `pnpm build` 通过。

> 注：用 `pnpm preview`（4173）测时 artalk 接口报 `Failed to fetch`。对照实验确认同样代码在 5500 端口正常加载 231 条评论，属 artalk.saop.cc 的 CORS 白名单未放行 4173，与本改动无关。

## 上线后说明

本次修复要生效，老用户仍需再经历一次「更新」—— 他们当前的旧 SW 还会命中旧 HTML 一次，之后才切换到新逻辑。此后不再复发。

🤖 Generated with [Claude Code](https://claude.com/claude-code)