### PR TITLE
修复 vTextScroll 的 XSS 与搜索历史加载不到的回归

### DIFF
--- a/src/components/SearchHistoryModal.vue
+++ b/src/components/SearchHistoryModal.vue
@@ -194,7 +194,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted } from 'vue'
+import { computed, ref, onMounted, watch } from 'vue'
 import { useUIStore } from '@/stores/ui'
 import { useHistoryStore } from '@/stores/history'
 import type { SearchHistory } from '@/utils/persistence'
@@ -244,14 +244,21 @@ const emit = defineEmits<{
 const open = computed({
   get: () => uiStore.isHistoryModalOpen,
   set: (value: boolean) => {
-    if (value) {
-      playTransitionUp()
-      historyStore.loadHistory()
-    } else {
-      playTransitionDown()
-    }
+    if (value) { playTransitionUp() } else { playTransitionDown() }
     uiStore.isHistoryModalOpen = value
   },
+})
+
+/**
+ * 加载必须用 watch 而不是塞进上面的 setter。
+ *
+ * setter 只在**组件自己**写 open 时才跑（点面板内的关闭按钮、Esc、点击外部）。
+ * 但打开这个面板的入口在别处：FloatingButtons 的 FAB 与键盘快捷键都是直接调
+ * uiStore.toggleHistoryModal() 改 store，绕过 setter —— 那样列表永远是空的。
+ * watch 监听 store 本身，无论谁改都会触发。
+ */
+watch(() => uiStore.isHistoryModalOpen, (isOpen) => {
+  if (isOpen) { historyStore.loadHistory() }
 })
 
 function handleSelectHistory(item: SearchHistory) {

--- a/src/composables/useTextScroll.ts
+++ b/src/composables/useTextScroll.ts
@@ -12,6 +12,21 @@ interface TextScrollElementExtended extends HTMLElement {
 }
 
 /**
+ * 用滚动容器包裹文本内容
+ *
+ * 必须用 textContent 赋值，不能拼进 innerHTML —— Vue 渲染时已经把内容转义成
+ * 文本，用 textContent 读回来拿到的是解码后的原始字符，再塞进 innerHTML 会让
+ * 其中的标记被重新解析成真实 HTML。本指令作用在用户可控的搜索历史条目上
+ * （SearchHistoryModal），形如 <img src=x onerror=...> 的搜索词会因此变成活的 DOM。
+ */
+function wrapContent(el: HTMLElement, content: string) {
+  const inner = document.createElement('span')
+  inner.className = 'text-scroll-inner'
+  inner.textContent = content
+  el.replaceChildren(inner)
+}
+
+/**
  * 检测元素文本是否溢出，并设置滚动动画
  */
 export const vTextScroll = {
@@ -24,7 +39,7 @@ export const vTextScroll = {
     // 保存并包装内容
     const content = el.textContent || ''
     extEl._textScrollContent = content
-    el.innerHTML = `<span class="text-scroll-inner">${content}</span>`
+    wrapContent(el, content)
     
     // 检查溢出
     const checkOverflow = () => {
@@ -91,7 +106,7 @@ export const vTextScroll = {
       if (!inner || currentContent !== extEl._textScrollContent) {
         const newContent = el.textContent || ''
         extEl._textScrollContent = newContent
-        el.innerHTML = `<span class="text-scroll-inner">${newContent}</span>`
+        wrapContent(el, newContent)
       }
       
       // 重新检查溢出


### PR DESCRIPTION
两个问题都已经在 #98 里上线了，是发布后检查未提交改动时发现的。**其中一个是 XSS，正在生产环境跑着**，建议尽快合。

## 1. vTextScroll 的 innerHTML XSS

```js
el.innerHTML = `<span class="text-scroll-inner">${el.textContent}</span>`
```

Vue 渲染时已经把内容转义成文本，用 `textContent` 读回来拿到的是**解码后的原始字符**，再塞进 `innerHTML` 会让其中的标记被重新解析成真实 HTML。

该指令作用在用户可控的搜索历史条目上（`SearchHistoryModal`），所以形如 `<img src=x onerror=...>` 的搜索词会变成活的 DOM 并执行。

改用 `createElement` + `textContent` + `replaceChildren` 构建包裹元素。

> 修复代码此前由另一个会话写好，但**一直未提交**、留在 `.claude/worktrees` 里，且基于重构前的旧文件，所以 #98 把带漏洞的版本发了上去。这次按当前代码重新应用。

## 2. 搜索历史打开后永远是空的

迁移到 Dialog 时（`a30c8f6`）把原来的 `watch(() => uiStore.isHistoryModalOpen)` 换成了 `v-model:open` 的 computed setter，加载逻辑跟着挪了进去。

但 setter **只在组件自己写 open 时才跑**（点面板内关闭按钮、Esc、点击外部）。而打开这个面板的入口都在别处 —— `FloatingButtons` 的 FAB 与键盘快捷键都是直接调 `uiStore.toggleHistoryModal()` 改 store，绕过 setter。

结果是从任何正常入口打开都显示「暂无搜索历史」，只有页面加载时面板恰好处于打开状态才会走 `onMounted` 那条分支加载成功 —— 这也是此前测试误判为正常的原因。

加载改回 `watch`（监听 store 本身，无论谁改都触发），音效留在 setter。

## 验证

生产构建 + 无 Service Worker 的干净 origin。在 localStorage 塞一条含 `<img src=x onerror="window.__xssFired=true">` 的搜索历史，从 FAB 打开面板：

- 列表正确显示 1 条 → 回归已修
- `.text-scroll` 的 innerHTML 为 `<span class="text-scroll-inner">&lt;img src=x ...&gt;千恋万花</span>` → 已转义
- 子元素只有 `SPAN.text-scroll-inner`，面板内 `img` 元素数 **0**
- `__xssFired` 为 **false** → payload 未执行

🤖 Generated with [Claude Code](https://claude.com/claude-code)