### PR TITLE
修复评论登录不可用与图片灯箱层级

### DIFF
--- a/src/components/CommentsModal.vue
+++ b/src/components/CommentsModal.vue
@@ -1,5 +1,19 @@
 <template>
-  <Dialog v-model:open="open">
+  <!--
+    modal={false} 是必须的，不是偷懒。
+
+    Artalk 用 document.body.appendChild 把自己的浮层容器 .atk-layer-wrap
+    （登录框、通知、图片查看器都在里面）挂在 body 上，也就是**这个 Dialog 的
+    DOM 子树之外**。而 Reka 的模态 Dialog 会给 body 加 pointer-events: none、
+    给外部兄弟节点加 aria-hidden、并装一个会把焦点拽回来的 focus trap ——
+    三条叠加的结果是评论登录框点不到、输不了字、屏幕阅读器也读不到。
+
+    迁移前这里是普通的 Teleport div，没有任何拦截，所以是这次迁移引入的回归。
+    托管会往 body 挂浮层的第三方组件，与捕获式模态框本质上不兼容。
+
+    代价是丢掉 Reka 自带的滚动锁定，下面用一个 watch 自己补上。
+  -->
+  <Dialog v-model:open="open" :modal="false">
     <DialogContent
       :show-close-button="false"
       class="comments-modal inset-0 flex translate-x-0 translate-y-0 flex-col gap-0 rounded-none border-0 p-0 shadow-2xl shadow-black/20
@@ -116,6 +130,36 @@ const open = computed({
     if (value) { playTransitionUp() } else { playTransitionDown() }
     uiStore.isCommentsModalOpen = value
   },
+})
+
+/**
+ * 自己做滚动锁定 —— 上面用了 modal={false}，Reka 的 useBodyScrollLock 不会生效。
+ *
+ * 记录进入前的 overflow 再还原，而不是无脑写 ''：这个面板可能在别的 Dialog
+ * （已经锁了滚动）之上打开，直接清空会把外层的锁一起解掉。
+ * 监听 store 而不是塞进上面的 setter：打开入口在 FloatingButtons 与快捷键里，
+ * 它们直接改 store、不走 setter（搜索历史面板就栽在这上面过）。
+ */
+let previousBodyOverflow: string | null = null
+
+watch(() => uiStore.isCommentsModalOpen, (isOpen) => {
+  if (isOpen) {
+    if (previousBodyOverflow === null) {
+      previousBodyOverflow = document.body.style.overflow
+    }
+    document.body.style.overflow = 'hidden'
+  } else if (previousBodyOverflow !== null) {
+    document.body.style.overflow = previousBodyOverflow
+    previousBodyOverflow = null
+  }
+})
+
+onUnmounted(() => {
+  // 组件被卸载时（异步组件可能被回收）别把锁留在 body 上
+  if (previousBodyOverflow !== null) {
+    document.body.style.overflow = previousBodyOverflow
+    previousBodyOverflow = null
+  }
 })
 
 // 检查并滚动到指定评论

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -160,12 +160,23 @@ onUnmounted(() => {
   <Dialog v-model:open="open">
     <!--
       灯箱要的是「整块黑幕就是内容」的观感，所以直接把 DialogContent 铺满全屏、
-      涂上 bg-black/95，Reka 自带的 overlay 藏在它底下。点击关闭也就落在这一层，
+      涂上纯黑，Reka 自带的 overlay 藏在它底下。点击关闭也就落在这一层，
       不再依赖 pointerDownOutside（全屏内容压根没有 outside）。
+
+      两处刻意的取值：
+
+      bg-black 而不是原来的 bg-black/95 —— 灯箱只从 VndbPanel 里打开，而那个
+      面板是 rgba(255,255,255,.85) 的白底，5% 的透光会让面板的矩形轮廓像鬼影
+      一样浮在黑幕上。原设计背后只有照片背景，5% 看不出来，套进 Dialog 之后
+      就露馅了。
+
+      z-[60] 而不是继承基类的 z-50 —— 项目里所有 Dialog / Popover / Tooltip
+      的内容与遮罩全是 z-50，同层级时纯靠挂载先后决定压盖。灯箱在语义上就是
+      「压在所有面板之上」的东西，把它显式抬到 60，就不必赌 portal 的挂载顺序。
     -->
     <DialogContent
       :show-close-button="false"
-      class="inset-0 flex max-w-none translate-x-0 translate-y-0 cursor-pointer items-center justify-center gap-0 rounded-none border-0 bg-black/95 p-0 shadow-none select-none sm:max-w-none"
+      class="inset-0 z-[60] flex max-w-none translate-x-0 translate-y-0 cursor-pointer items-center justify-center gap-0 rounded-none border-0 bg-black p-0 shadow-none select-none sm:max-w-none"
       @click="open = false"
       @touchstart="handleTouchStart"
       @touchend="handleTouchEnd"


### PR DESCRIPTION
两个都是上一轮 shadcn 迁移引入的回归，现在在生产环境跑着。

## 1. 评论登录框点不到、输不了字

Artalk 用 `document.body.appendChild` 把浮层容器 `.atk-layer-wrap`（登录框、通知、图片查看器都在里面）挂在 body 上，也就是 `CommentsModal` 这个 Dialog 的 DOM 子树**之外**。而 Reka 的模态 Dialog 会：

- 给 `body` 加 `pointer-events: none`（只有 Dialog 自己的节点是 `auto`）
- 给 Dialog 之外的 body 子元素加 `aria-hidden="true"`
- 装一个 focus trap，焦点移到外面就拽回来

三条叠加 → 登录框既点不到、也聚焦不了、屏幕阅读器还读不到。

迁移前这里是普通 Teleport，没有任何拦截。托管「会往 body 挂浮层的第三方组件」与捕获式模态框本质不兼容，改用 `:modal="false"`。

滚动锁定用一个 `watch` 自己补上：记录进入前的 `body.style.overflow` 再还原（不无脑清空，因为这个面板可能在别的已锁滚动的 Dialog 之上打开）；监听 store 而非 `v-model:open` 的 setter，因为打开入口在 FloatingButtons 与快捷键里，它们直接改 store 不走 setter。

> `:modal="false"` 后不再渲染 DialogOverlay，评论面板没有遮罩了 —— 这与迁移前一致（原实现本来就没有遮罩）。相比原版仍是净增益：多了 Esc、点击外部关闭、role/aria 与滚动锁定。

## 2. 图片灯箱显示在 VNDB 面板下面

复现：打开作品介绍 → 点里面的截图 → 灯箱在面板下面。

两处原因，都与「灯箱现在是从一个 Dialog 里打开的」有关（迁移前它背后只有页面本身）：

- **`bg-black/95` → `bg-black`**：那 5% 透光原本无害，但 VndbPanel 是 `rgba(255,255,255,.85)` 白底，透出来是个明显更亮的矩形鬼影
- **`z-50` → `z-[60]`**：项目里所有 Dialog / Popover / Tooltip 的内容与遮罩全是 `z-50`，同层级纯靠 portal 挂载先后定胜负。灯箱语义上就该压在所有面板之上，显式抬高就不必赌顺序

## 验证

评论侧（不依赖视觉，全是计算样式与事件行为）：`body` 的 `pointer-events` 由 `none` 变回 `auto`；往 body 挂一个模拟 Artalk 的浮层，其 `pointer-events` 为 `auto`、无 `aria-hidden`、click 事件可达、**内部输入框能拿到并保持焦点**（修复前会被 focus trap 拽走）；面板打开时 `body` overflow 为 `hidden`，关闭后还原。

灯箱侧：走**截图**那条路径（`openGallery(index + 1)`）点开，灯箱为 `z: 60`、`backgroundColor: rgb(0, 0, 0)` 完全不透明，且是所有 open 状态 Dialog 里的最高层；VNDB 面板为 `z: 50`。

> ⚠️ 灯箱的**观感**未能在开发环境确认：无头浏览器面板的截图管线会做降透明度合成，截图一律偏灰（同批症状还有视口报 0x0、`elementFromPoint` 恒返回 null、CSS 动画零事件、关闭的 Dialog 因等不到 `animationend` 而不卸载）。合并后请在真实浏览器确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)