### PR TITLE
建立显式的 z-index 刻度

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,35 @@ svg 的 width/height **属性**，而 `buttonVariants` 基类里的
 <Button size="icon"><ChevronLeft :size="24" class="size-6" /></Button>
 ```
 
+### 层级刻度
+
+全局层叠用 `src/styles/tailwind.css` 里的刻度，不要再写裸数字：
+
+| 工具类 | 值 | 用途 |
+|--------|----|----|
+| `z-background` | -2 | Ken Burns 背景图层 |
+| `z-backdrop` | 1 | 背景之上的可读性遮罩 |
+| `z-floating` | 40 | 顶部工具栏、FAB、统计角标（互不重叠） |
+| `z-modal` | 50 | 模态遮罩与内容 |
+| `z-lightbox` | 60 | 图片灯箱（从面板里打开，须压在面板之上） |
+| `z-toast` | 70 | 全局提示 |
+| `z-progress` | 80 | 顶部加载进度条 |
+
+两条边界：
+
+**只管全局层叠。** 组件内部的层级（搜索框里的图标与进度填充、灯箱里的按钮、
+ToggleGroupItem 的 focus 提升）各自处在自己的层叠上下文中，继续用 `z-10` /
+`z-20` 这类小数字是对的，纳入刻度反而误导。
+
+**`z-modal` 的 50 不能改。** 它是 shadcn 生成组件写死的值（`DialogOverlay` /
+`DialogContent` / `PopoverContent` / `TooltipContent` 基类里都是 `z-50`，
+位于 vendored 的 `components/ui/` 下，每次 `shadcn-vue add` 都会被重写）。
+刻度里保留这一档是为了让其余档位有明确的参照，改只能改别的档。
+
+> 为什么要这套：迁移到 shadcn 后 TopToolbar 与所有 Dialog/Popover/Tooltip
+> 全挤在 z-50，压盖关系纯靠 portal 挂载先后决定。「作品介绍面板里点截图，
+> 灯箱出现在面板下面」就是这么来的。
+
 ### 液态玻璃效果
 
 样式定义在 `src/styles/glassmorphism.css`，直接加单个类即可，无需嵌套结构：

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,7 +12,7 @@
     <!-- 背景层容器 - GPU 加速 -->
     <div
       id="background-container" 
-      class="fixed inset-0 z-[-2] overflow-hidden gpu-layer"
+      class="fixed inset-0 z-background overflow-hidden gpu-layer"
     >
       <!-- 默认背景纹理（无图片时显示） -->
       <div
@@ -29,7 +29,7 @@
       />
       
       <!-- 半透明遮罩层（提升内容可读性） -->
-      <div class="absolute inset-0 bg-white/15 dark:bg-slate-900/30 z-[1]" />
+      <div class="absolute inset-0 bg-white/15 dark:bg-slate-900/30 z-backdrop" />
     </div>
 
     <main class="flex-1 flex flex-col min-h-screen">

--- a/src/components/FloatingButtons.vue
+++ b/src/components/FloatingButtons.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- 浮动按钮组 -->
-  <div class="floating-buttons fixed bottom-4 sm:bottom-6 right-4 sm:right-6 flex flex-col gap-2 sm:gap-3 z-40">
+  <div class="floating-buttons fixed bottom-4 sm:bottom-6 right-4 sm:right-6 flex flex-col gap-2 sm:gap-3 z-floating">
     <!-- 回到顶部按钮 - 显示滚动进度 -->
     <button
       v-show="showScrollToTop"

--- a/src/components/ImageViewer.vue
+++ b/src/components/ImageViewer.vue
@@ -170,13 +170,14 @@ onUnmounted(() => {
       一样浮在黑幕上。原设计背后只有照片背景，5% 看不出来，套进 Dialog 之后
       就露馅了。
 
-      z-[60] 而不是继承基类的 z-50 —— 项目里所有 Dialog / Popover / Tooltip
+      z-lightbox 而不是继承基类的 z-50 —— 项目里所有 Dialog / Popover / Tooltip
       的内容与遮罩全是 z-50，同层级时纯靠挂载先后决定压盖。灯箱在语义上就是
-      「压在所有面板之上」的东西，把它显式抬到 60，就不必赌 portal 的挂载顺序。
+      「压在所有面板之上」的东西，显式抬高就不必赌 portal 的挂载顺序。
+      刻度定义见 styles/tailwind.css 的「层级刻度」一节。
     -->
     <DialogContent
       :show-close-button="false"
-      class="inset-0 z-[60] flex max-w-none translate-x-0 translate-y-0 cursor-pointer items-center justify-center gap-0 rounded-none border-0 bg-black p-0 shadow-none select-none sm:max-w-none"
+      class="inset-0 z-lightbox flex max-w-none translate-x-0 translate-y-0 cursor-pointer items-center justify-center gap-0 rounded-none border-0 bg-black p-0 shadow-none select-none sm:max-w-none"
       @click="open = false"
       @touchstart="handleTouchStart"
       @touchend="handleTouchEnd"

--- a/src/components/StatsCorner.vue
+++ b/src/components/StatsCorner.vue
@@ -5,7 +5,7 @@
     而 App.vue 不在本次改动范围内；将来 App.vue 有了全局 Provider 就能删掉这一层。
   -->
   <TooltipProvider :delay-duration="400">
-    <div class="fixed top-4 left-4 z-40">
+    <div class="fixed top-4 left-4 z-floating">
       <Tooltip>
         <TooltipTrigger as-child>
           <a
@@ -42,7 +42,7 @@
 
   <!-- 左下角统计（Vue 控制显示） -->
   <div
-    class="fixed bottom-4 left-4 z-40 transition-all duration-300"
+    class="fixed bottom-4 left-4 z-floating transition-all duration-300"
     :class="showStats ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-4 pointer-events-none'"
   >
     <div class="stats-card glassmorphism-card rounded-2xl shadow-lg px-4 py-3 flex flex-col gap-2">

--- a/src/components/TopToolbar.vue
+++ b/src/components/TopToolbar.vue
@@ -5,7 +5,7 @@
     嵌套 Provider 只是内层覆盖外层的延迟配置，没有副作用。
   -->
   <TooltipProvider :delay-duration="400">
-    <div class="top-toolbar fixed top-4 right-4 z-50 flex items-center gap-2 sm:gap-3">
+    <div class="top-toolbar fixed top-4 right-4 z-floating flex items-center gap-2 sm:gap-3">
       <!-- 保存背景图按钮 -->
       <Tooltip>
         <TooltipTrigger as-child>

--- a/src/components/UpdateToast.vue
+++ b/src/components/UpdateToast.vue
@@ -19,7 +19,7 @@
       role="status"
       aria-live="polite"
       aria-atomic="true"
-      class="fixed bottom-4 left-1/2 -translate-x-1/2 z-[100] px-4 py-3 rounded-2xl bg-gradient-to-r from-theme-primary to-theme-accent text-white shadow-xl shadow-theme-primary/30 flex items-center gap-3 max-w-[90vw] sm:max-w-md"
+      class="fixed bottom-4 left-1/2 -translate-x-1/2 z-toast px-4 py-3 rounded-2xl bg-gradient-to-r from-theme-primary to-theme-accent text-white shadow-xl shadow-theme-primary/30 flex items-center gap-3 max-w-[90vw] sm:max-w-md"
     >
       <!-- 图标：Tailwind v4 已移除 flex-shrink-* 别名，这里必须写 shrink-0 才真的不被压扁 -->
       <div class="shrink-0 w-8 h-8 rounded-full bg-white/20 flex items-center justify-center">

--- a/src/composables/useProgress.ts
+++ b/src/composables/useProgress.ts
@@ -50,7 +50,7 @@ function createElements() {
         top: 0;
         left: 0;
         right: 0;
-        z-index: 9999;
+        z-index: var(--z-progress, 80);
       }
       
       #progress-bar .progress-bar {
@@ -86,7 +86,7 @@ function createElements() {
         position: fixed;
         top: 16px;
         right: 16px;
-        z-index: 9999;
+        z-index: var(--z-progress, 80);
       }
       
       #progress-bar .spinner-icon {

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -29,6 +29,45 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 /*
+ * ============================================================
+ * 层级刻度
+ * ============================================================
+ *
+ * 只管**全局层叠**：那些会跨组件互相竞争的固定/绝对定位层。
+ * 组件内部的层叠（搜索框里的图标与进度填充、灯箱里的按钮、ToggleGroupItem
+ * 的 focus 提升）不在这套刻度里 —— 它们各自处在自己的层叠上下文中，
+ * 用 z-10 / z-20 这类小数字是对的，纳进来反而会误导。
+ *
+ * 之所以要显式刻度：迁移到 shadcn 之后，TopToolbar、所有 Dialog 的遮罩与
+ * 内容、Popover、Tooltip 全都挤在 z-50，压盖关系纯靠 portal 的挂载先后决定。
+ * 「作品介绍面板里点截图，灯箱出现在面板下面」就是这么来的 —— 靠巧合工作的
+ * 东西迟早会翻。
+ *
+ * ⚠️ modal = 50 这一档是 shadcn 生成组件写死的（DialogOverlay / DialogContent /
+ * PopoverContent / TooltipContent 基类里都是 z-50，位于 vendored 的
+ * components/ui/ 下，每次 `shadcn-vue add` 都会被重写）。所以这一档的数值
+ * **不能改**，只能围绕它排布其余档位。同一个 Dialog 内部遮罩与内容都是 50，
+ * 但它们是相邻兄弟且顺序正确，不需要区分。
+ */
+:root {
+  --z-background: -2;  /* Ken Burns 背景图层，在文档流之下 */
+  --z-backdrop: 1;     /* 背景之上的可读性遮罩 */
+  --z-floating: 40;    /* 常驻浮动 UI：顶部工具栏、FAB、统计角标（互不重叠） */
+  --z-modal: 50;       /* 模态遮罩与内容 —— shadcn 基类固定值，不可改 */
+  --z-lightbox: 60;    /* 图片灯箱：从面板里打开，必须压在所有面板之上 */
+  --z-toast: 70;       /* 全局提示（SW 更新），要能盖住模态 */
+  --z-progress: 80;    /* 顶部加载进度条，永远最上 */
+}
+
+@utility z-background { z-index: var(--z-background); }
+@utility z-backdrop { z-index: var(--z-backdrop); }
+@utility z-floating { z-index: var(--z-floating); }
+@utility z-modal { z-index: var(--z-modal); }
+@utility z-lightbox { z-index: var(--z-lightbox); }
+@utility z-toast { z-index: var(--z-toast); }
+@utility z-progress { z-index: var(--z-progress); }
+
+/*
  * 圆角刻度 —— 项目自己的一套，且用户可在设置面板里切档（直角/小/适中/圆润）。
  *
  * 这组变量原本写在 glassmorphism.css 的无 layer :root 里，等于"意外"覆盖了


### PR DESCRIPTION
结构性改动，不含紧急修复（评论登录与灯箱的修复已在 #100 上线）。

## 为什么

迁移到 shadcn 之后，`TopToolbar` 与所有 Dialog 的遮罩/内容、`Popover`、`Tooltip` 全都挤在 `z-50`，压盖关系纯靠 portal 的挂载先后决定。上一轮那个「作品介绍面板里点截图、灯箱出现在面板下面」就是这么来的 —— 靠巧合工作的东西迟早会翻。

## 刻度

定义在 `src/styles/tailwind.css`：

| 工具类 | 值 | 用途 |
|--------|----|----|
| `z-background` | -2 | Ken Burns 背景图层 |
| `z-backdrop` | 1 | 背景之上的可读性遮罩 |
| `z-floating` | 40 | 顶部工具栏、FAB、统计角标（互不重叠） |
| `z-modal` | 50 | 模态遮罩与内容 |
| `z-lightbox` | 60 | 图片灯箱 |
| `z-toast` | 70 | 全局提示 |
| `z-progress` | 80 | 顶部加载进度条 |

用 `@utility` 生成工具类 —— Tailwind v4 的 z-index 没有主题命名空间，实测 `--z-index-*` 完全不生成任何工具类，`@utility` 才行。

关键改动是 **`TopToolbar` 从 `z-50` 降到 `z-floating`(40)**：它此前与模态同级，是否被遮罩盖住全看 DOM 顺序。

## 两条刻意的边界

**只管全局层叠。** 组件内部的层级（搜索框里的图标与进度填充、灯箱内部的按钮、`ToggleGroupItem` 的 focus 提升、`.text-scroll` 的渐隐遮罩、`vRipple` 的涟漪）各自处在自己的层叠上下文里，继续用小数字是对的，没有纳入刻度 —— 硬塞进去反而误导。

**`z-modal` 的 50 不可改。** 那是 shadcn 生成组件写死的值（`DialogOverlay` / `DialogContent` / `PopoverContent` / `TooltipContent` 基类都是 `z-50`），位于 vendored 的 `components/ui/` 下，每次 `shadcn-vue add` 都会被重写。刻度里保留这一档只是为了给其余档位一个明确参照。同一个 Dialog 内部遮罩与内容同为 50，但它们是相邻兄弟且顺序正确，无需区分。

`useProgress` 运行时注入样式里的两处 `z-index: 9999` 也接进了 `var(--z-progress)`。

## 验证

产物中七个变量与用到的五个工具类均正确生成。浏览器实测排序：

```
背景 -2 → 工具栏/FAB 40 → 模态遮罩/面板 50 → 灯箱 60
```

`灯箱高于面板`、`工具栏低于模态` 均为真。CLAUDE.md 补了刻度表与上述两条边界说明。

🤖 Generated with [Claude Code](https://claude.com/claude-code)